### PR TITLE
Fix code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/api.py
+++ b/api.py
@@ -108,10 +108,11 @@ def analyze_stock(ticker):
         
         return jsonify(response)
     except Exception as e:
+        app.logger.error(f"Error analyzing stock {ticker.upper()}: {str(e)}")
         return jsonify({
-            'error': str(e),
+            'error': 'An internal error has occurred. Please try again later.',
             'ticker': ticker.upper()
-        }), 400
+        }), 500
 
 # Health check endpoint
 @app.route('/api/health', methods=['GET'])


### PR DESCRIPTION
Fixes [https://github.com/skytells-research/stock-risk-analyzer/security/code-scanning/3](https://github.com/skytells-research/stock-risk-analyzer/security/code-scanning/3)

To fix the problem, we should avoid returning the exception message directly to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This ensures that sensitive information is not exposed while still allowing developers to debug issues using the server logs.

1. Modify the exception handling block to log the exception message.
2. Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
