### PR TITLE
fix: compiling bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv
+.idea
+.DS_Store

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@
 flask==3.0.2
 numpy==1.26.4
 pandas==2.2.1
-scikit-learn==1.5.0
+scikit-learn==1.3.0
 yfinance==0.2.37
-pandas_ta==0.7.0
+pandas_ta==0.3.14b
 joblib==1.3.2
 
 # Data handling and processing

--- a/templates/index.html
+++ b/templates/index.html
@@ -270,6 +270,10 @@
             color: #000000;
         }
 
+        [data-theme="dark"] .analytics-item > p {
+            color: var(--secondary-color);
+        }
+
         .theme-toggle-btn:hover {
             opacity: 0.8;
             background: none !important;


### PR DESCRIPTION
Code not compilable had to update two libs versions in the requirements.txt
- scikit-learn: from 1.5.0 to 1.3.0, implementation change in the lib
- pandas_ta: from 0.7.0 to 0.3.14b, there is no 0.7.0 version

## System Environment

- OS: macOS 15.1
- Python: 3.10 also tried with 3.11

## Issue 1

### Scenario

On running the 3rd step of the installation guide, `3. Install the dependencies` which is running this command.

```bash
pip install -r requirements.txt
```

I'm getting this Error Message:

```
ERROR: Could not find a version that satisfies the requirement pandas_ta==0.7.0 (from versions: 0.0.4a0, 0.0.5a0, 0.0.7a0, 0.1.0a0, 0.1.2a0, 0.1.13a0, 0.1.16b0, 0.1.25b0, 0.1.30b0, 0.1.31b0, 0.1.32b0, 0.1.36b0, 0.1.39b0, 0.1.66b0, 0.1.97b0, 0.2.23b0, 0.2.45b0, 0.3.2b0, 0.3.14b0)
ERROR: No matching distribution found for pandas_ta==0.7.0
```

### Investigation

Upon checking the official [GitHub repo](https://github.com/twopirllc/pandas-ta) for the lib, I found that version 0.7.0 doesn't exist.

List of [available versions](https://pypi.org/project/pandas-ta/0.3.14b/) are:

- 0.0.4a0
- 0.0.5a0
- 0.0.7a0
- 0.1.0a0
- 0.1.2a0
- 0.1.13a0
- 0.1.16b0
- 0.1.25b0
- 0.1.30b0
- 0.1.31b0
- 0.1.32b0
- 0.1.36b0
- 0.1.39b0
- 0.1.66b0
- 0.1.97b0
- 0.2.23b0
- 0.2.45b0
- 0.3.2b0
- 0.3.14b0

### Fix

Updated the `requirements.txt` file for that lib to `pandas_ta==0.3.14b,` which is the latest version as of this post.

## Issue 2

### Scenario

Upon running the system and providing a stock ticker "APPL", I get `An internal error has occurred.`

[Error Screenshot](https://imgur.com/a/qkq28Or)

### Investigation

Upon further investigation, I got to the root cause of the error, which is 
```
sklearn/base.py:376: InconsistentVersionWarning: Trying to unpickle estimator DecisionTreeClassifier from version 1.3.0 when using version 1.5.0. This might lead to breaking code or invalid results. Use at your own risk. For more info please refer to:
https://scikit-learn.org/stable/model_persistence.html#security-maintainability-limitations
warnings.warn(
/usr/local/lib/python3.10/site-packages/sklearn/base.py:376: InconsistentVersionWarning: Trying to unpickle estimator RandomForestClassifier from version 1.3.0 when using version 1.5.0. This might lead to breaking code or invalid results. Use at your own risk. For more info please refer to:
https://scikit-learn.org/stable/model_persistence.html#security-maintainability-limitations
warnings.warn(
ERROR:root:Traceback (most recent call last):
   File "/app/app.py", line 34, in analyze
            risk_level = model.predict(latest_data.values.reshape(1, -1))[0]
       File "/usr/local/lib/python3.10/site-packages/sklearn/ensemble/_forest.py", line 904, in predict
           proba = self.predict_proba(X)
        File "/usr/local/lib/python3.10/site-packages/sklearn/ensemble/_forest.py", line 946, in predict_proba
           X = self._validate_X_predict(X)
        File "/usr/local/lib/python3.10/site-packages/sklearn/ensemble/_forest.py", line 636, in _validate_X_predict
           if self.estimators_[0]._support_missing_values(X):
       File "/usr/local/lib/python3.10/site-packages/sklearn/tree/_classes.py", line 188, in _support_missing_values
           and self.monotonic_cst is None
AttributeError: 'DecisionTreeClassifier' object has no attribute 'monotonic_cst'
```

### Fix

Downgrading the lib to `scikit-learn==1.3.0` fixed the issue.

Now, I only have the following warning.
```
/usr/local/lib/python3.10/site-packages/sklearn/base.py:464: UserWarning: X does not have valid feature names, but RandomForestClassifier was fitted with feature names
```

## Issue 3

Fixed text colour in the darkmode. It was very light gray and it's background was white which made it difficult to be read. I've added a new `CSS` rule that will fix that issue.